### PR TITLE
Add URL params for most of the settings (e.g. username, color, date...)

### DIFF
--- a/src/app/util.js
+++ b/src/app/util.js
@@ -73,3 +73,16 @@ export function isDateMoreRecentThan(date, than) {
     } 
     return new Date(date)>new Date(than)
 }
+
+// Expects an ISO 8601 date i.e. YYYY-MM-DD
+// If invalid, returns null
+export function parseDate(dateString) {
+    const pattern = /^(\d{4})-(\d{2})-(\d{2})$/
+    const matchResult = dateString.match(pattern)
+    if (!matchResult) {
+        return null
+    }
+    let [year, month, date] = matchResult.map(n => +n).slice(1);
+    month = month - 1
+    return new Date(year, month, date)
+}

--- a/src/pres/loader/Filters.js
+++ b/src/pres/loader/Filters.js
@@ -22,10 +22,12 @@ export default class User extends React.Component {
 
     constructor(props) {
         super(props)
+
+        let isAdvancedFiltersOpen = new URLSearchParams(window.location.search).get("advanced") === 'true'
+
         this.state = {
             playerColor: this.props.playerColor,
-            isAdvancedFiltersOpen: false
-
+            isAdvancedFiltersOpen: isAdvancedFiltersOpen
         }
         Object.assign(this.state, this.props.advancedFilters)
         this.defaultAdvancedFilters = this.props.advancedFilters

--- a/src/pres/loader/PGNLoader.js
+++ b/src/pres/loader/PGNLoader.js
@@ -20,6 +20,7 @@ export default class PGNLoader extends React.Component {
         let color = new URLSearchParams(window.location.search).get("color") // 'white' | 'black'
         // 'all' | 'rated' | 'casual' (corresponds to Filters.toggleRated)
         let ratedMode = new URLSearchParams(window.location.search).get("ratedMode")
+        let timeControls = this.getTimeControls()
 
         this.state = {
             playerName: playerName?playerName:'',
@@ -34,19 +35,13 @@ export default class PGNLoader extends React.Component {
             selectedNotableEvent:{},
             selectedNotablePlayer:{},
             lichessLoginState: Constants.LICHESS_NOT_LOGGED_IN,
-            lichessLoginName: null
+            lichessLoginName: null,
+            ...timeControls
         }
         if(selectedSite === Constants.SITE_LICHESS) {
             this.fetchLichessLoginStatus()
         }
         this.state[Constants.FILTER_NAME_DOWNLOAD_LIMIT] = Constants.MAX_DOWNLOAD_LIMIT
-        this.state[Constants.TIME_CONTROL_ULTRA_BULLET] = true
-        this.state[Constants.TIME_CONTROL_BULLET] = true
-        this.state[Constants.TIME_CONTROL_BLITZ] = true
-        this.state[Constants.TIME_CONTROL_RAPID] = true
-        this.state[Constants.TIME_CONTROL_CLASSICAL] = true
-        this.state[Constants.TIME_CONTROL_CORRESPONDENCE] = true
-        this.state[Constants.TIME_CONTROL_DAILY] = true
         this.state[Constants.FILTER_NAME_RATED] = ratedMode ? ratedMode : "all"
         this.state[Constants.FILTER_NAME_ELO_RANGE] = [0, Constants.MAX_ELO_RATING]
         this.state[Constants.FILTER_NAME_OPPONENT] = ''
@@ -219,6 +214,34 @@ export default class PGNLoader extends React.Component {
             return 'user'
         } else {
             return 'filters'
+        }
+    }
+    getTimeControls() {
+        let selectedChoices = new URLSearchParams(window.location.search).get("timeControls")
+
+        const allChoices = [
+            Constants.TIME_CONTROL_ULTRA_BULLET,
+            Constants.TIME_CONTROL_BULLET,
+            Constants.TIME_CONTROL_BLITZ,
+            Constants.TIME_CONTROL_RAPID,
+            Constants.TIME_CONTROL_CLASSICAL,
+            Constants.TIME_CONTROL_CORRESPONDENCE,
+            Constants.TIME_CONTROL_DAILY
+        ]
+
+        if (!selectedChoices) {
+            const result = {}
+            for (const choice of allChoices) {
+                result[choice] = true
+            }
+            return result
+        } else {
+            selectedChoices = selectedChoices.split(',')
+            const result = {}
+            for (const choice of allChoices) {
+                result[choice] = selectedChoices.includes(choice)
+            }
+            return result
         }
     }
 

--- a/src/pres/loader/PGNLoader.js
+++ b/src/pres/loader/PGNLoader.js
@@ -18,6 +18,8 @@ export default class PGNLoader extends React.Component {
         let selectedSite = new URLSearchParams(window.location.search).get("source")
         let playerName = new URLSearchParams(window.location.search).get("playerName")
         let color = new URLSearchParams(window.location.search).get("color") // 'white' | 'black'
+        // 'all' | 'rated' | 'casual' (corresponds to Filters.toggleRated)
+        let ratedMode = new URLSearchParams(window.location.search).get("ratedMode")
 
         this.state = {
             playerName: playerName?playerName:'',
@@ -45,7 +47,7 @@ export default class PGNLoader extends React.Component {
         this.state[Constants.TIME_CONTROL_CLASSICAL] = true
         this.state[Constants.TIME_CONTROL_CORRESPONDENCE] = true
         this.state[Constants.TIME_CONTROL_DAILY] = true
-        this.state[Constants.FILTER_NAME_RATED] = "all"
+        this.state[Constants.FILTER_NAME_RATED] = ratedMode ? ratedMode : "all"
         this.state[Constants.FILTER_NAME_ELO_RANGE] = [0, Constants.MAX_ELO_RATING]
         this.state[Constants.FILTER_NAME_OPPONENT] = ''
     }

--- a/src/pres/loader/PGNLoader.js
+++ b/src/pres/loader/PGNLoader.js
@@ -17,11 +17,12 @@ export default class PGNLoader extends React.Component {
         super(props)
         let selectedSite = new URLSearchParams(window.location.search).get("source")
         let playerName = new URLSearchParams(window.location.search).get("playerName")
+        let color = new URLSearchParams(window.location.search).get("color") // 'white' | 'black'
 
         this.state = {
             playerName: playerName?playerName:'',
             site: selectedSite?selectedSite:'',
-            playerColor: this.props.settings.playerColor,
+            playerColor: color ? color : this.props.settings.playerColor,
             isAdvancedFiltersOpen: false,
             isGamesSubsectionOpen: false,
             expandedPanel: this.getInitiallyExpandedPanel(selectedSite, playerName),

--- a/src/pres/loader/PGNLoader.js
+++ b/src/pres/loader/PGNLoader.js
@@ -16,14 +16,15 @@ export default class PGNLoader extends React.Component {
     constructor(props) {
         super(props)
         let selectedSite = new URLSearchParams(window.location.search).get("source")
+        let playerName = new URLSearchParams(window.location.search).get("playerName")
 
         this.state = {
-            playerName: '',
+            playerName: playerName?playerName:'',
             site: selectedSite?selectedSite:'',
             playerColor: this.props.settings.playerColor,
             isAdvancedFiltersOpen: false,
             isGamesSubsectionOpen: false,
-            expandedPanel: selectedSite?'user':'source',
+            expandedPanel: this.getInitiallyExpandedPanel(selectedSite, playerName),
             notablePlayers:null,
             notableEvents:null,
             files:[],
@@ -207,6 +208,15 @@ export default class PGNLoader extends React.Component {
         this.setState({expandedPanel:'source'})
         this.props.variantChange(newVariant)
         trackEvent(Constants.EVENT_CATEGORY_PGN_LOADER, "VariantChange", newVariant)
+    }
+    getInitiallyExpandedPanel(selectedSite, playerName) {
+        if (!selectedSite) {
+            return 'source'
+        } else if (!playerName) {
+            return 'user'
+        } else {
+            return 'filters'
+        }
     }
 
     render() {

--- a/src/pres/loader/PGNLoader.js
+++ b/src/pres/loader/PGNLoader.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { createSubObjectWithProperties } from '../../app/util'
+import { createSubObjectWithProperties, parseDate } from '../../app/util'
 import * as Constants from '../../app/Constants'
 import { trackEvent } from '../../app/Analytics'
 import Source from './Source'
@@ -20,6 +20,8 @@ export default class PGNLoader extends React.Component {
         let color = new URLSearchParams(window.location.search).get("color") // 'white' | 'black'
         // 'all' | 'rated' | 'casual' (corresponds to Filters.toggleRated)
         let ratedMode = new URLSearchParams(window.location.search).get("ratedMode")
+        let fromDate = new URLSearchParams(window.location.search).get("fromDate") // YYYY-MM-DD
+        let toDate = new URLSearchParams(window.location.search).get("toDate") // YYYY-MM-DD
         let timeControls = this.getTimeControls()
 
         this.state = {
@@ -45,6 +47,8 @@ export default class PGNLoader extends React.Component {
         this.state[Constants.FILTER_NAME_RATED] = ratedMode ? ratedMode : "all"
         this.state[Constants.FILTER_NAME_ELO_RANGE] = [0, Constants.MAX_ELO_RATING]
         this.state[Constants.FILTER_NAME_OPPONENT] = ''
+        this.state[Constants.FILTER_NAME_FROM_DATE] = fromDate ? parseDate(fromDate) : null
+        this.state[Constants.FILTER_NAME_TO_DATE] = toDate ? parseDate(toDate) : null
     }
 
 

--- a/src/pres/loader/User.js
+++ b/src/pres/loader/User.js
@@ -23,7 +23,7 @@ export default class User extends React.Component {
     constructor(props) {
         super(props)
         this.state = {
-            playerName:'',
+            playerName:this.props.playerName,
             tournamentUrl:'',
             files:[],
             selectedPlayer:{},


### PR DESCRIPTION
Hi vjuneja! Here's a PR for broader URL params support (as we talked about on Discord a month or two ago).

My goal / use case is just for searching for lichess users (& setting player name, color, mode, time control, date), so it's quite possible there are edge cases I've missed in interactions with the other sources (chess.com users, lichess tournaments, .tree files, etc).

I'm also quite happy to add support to all the other different settings if that's something you'd like me to do (while I'm looking at this stuff anyway) -- I figured I'd get your eyes on this smaller PR first, fix anything that comes up first, then try to tackle the other settings. (Currently missing handling for: lichess tournaments & selecting a tournament, notable players/events & selecting a player/event from the dropdown, rating range, opponent name, download limit)

I'm happy to change anything in here, of course -- let me know what feedback you've got! (In particular, I'm not very experienced with React, so if there's anything unidiomatic etc I would love to know about it!) We can also hop on Discord to voice chat if that would be helpful.

Also, this PR description is super long but (as I think you'll see) this is not terribly complicated stuff -- I just wanted to be thorough and document everything, esp. edge cases. Hopefully that's helpful!

----

## This PR adds these params:

Corresponding to filters:

- `playerName` (string)
- `color` (`white` or `black`)
- `ratedMode` (`all` or `rated` or `casual`)
- `fromDate` (string in `YYYY-MM-DD` format)
- `toDate` (string in `YYYY-MM-DD` format)
- `timeControls` (string: comma-separated list of `blitz` `bullet` etc)

It also adds this param:

- `advanced`: (boolean) -- Whether the "advanced filters" panel is expanded or not. Another approach we could take is to not have this param and instead do something smarter (like have the panel expand if and only if one of the filters in there has been set in a URL param), but this was simplest to start with.

## Which panel is expanded on page load?

This is just the logical extension of what you're already doing with `expandedPanel: selectedSite?'user':'source'` in PGNLoader.js, but worth mentioning:

- With no params, we start with the Source panel
- If `source` param is used, we skip the Source panel and go to the User panel
- If both `source` and `playerName` are used, we skip all the way to the Filters panel

So, it's also worth mentioning explicitly that...

## ...All params are optional:

- If `advanced` is omitted, it defaults to false (same behavior as current OpeningTree).
- If any of the other params (the ones corresponding to filters) is omitted, it's the same as current OpeningTree behavior (depends on which param -- playerName is blank, color is unselected, ratedMode defaults to all, fromDate defaults to Big Bang, etc)

This brings me to...

## ...What if "later" params are provided but "earlier" params are omitted?

This seems to work just fine. If you omit, say, `playerName`, but provides `color`, then the user has to type in a name. But when they get to the Filters panel, the color will be filled in for them already! :)

Also, re. "which panel is expanded" -- if you provide `playerName` and omit `source`, then (since `source` is omitted) we have to start at the Source panel, but when the user gets to the User panel, the name will already be there. (Possible improvement(?): Skip the User panel, since the name has already been set. Again, keeping it simple... :) )

## A few more notes in PR comments

(currently adding these)
