### PR TITLE
factor out offCard & always be able to modify book settings

### DIFF
--- a/src/pres/moves/BookMoves.js
+++ b/src/pres/moves/BookMoves.js
@@ -2,12 +2,9 @@ import React from 'react'
 import MovesTable from './MovesTable'
 import ResultsTable from './ResultsTable';
 import { Spinner } from 'reactstrap';
-import {Card, CardBody, CardText, CardTitle} from 'reactstrap'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faInfoCircle} from '@fortawesome/free-solid-svg-icons'
-import { Button as MaterialUIButton } from '@material-ui/core'
 import Cached from '@material-ui/icons/Cached'
 import * as Constants from '../../app/Constants'
+import { offCard } from './MovesCommon'
 
 export default class BookMove extends React.Component {
 
@@ -30,19 +27,18 @@ export default class BookMove extends React.Component {
             return <div className="center"><br/><Spinner/></div>
         }
         if(this.props.bookMoves.fetch === "off") {
-            return this.offCard('Opening book is disabled',
-                'Click the button below to enable it',
-                this.enableBook.bind(this),'Enable opening book', <Cached />)
+            return offCard('Opening book is disabled',
+                           'Click the button below to enable it',
+                           this.enableBook.bind(this),
+                           'Enable opening book',
+                           <Cached />)
         }
-
         if(this.props.bookMoves.fetch === "failed") {
-            return this.offCard('Failed to fetch book moves',
-                'Please check your internet connection. Lichess could also be down.',
-                this.props.forceFetchBookMoves,'Try again', <Cached />)
-        }
-        if(this.props.bookMoves.moves.length === 0) {
-            return this.offCard('No moves found',
-                'The opening book does not have any moves in this position')
+            return offCard('Failed to fetch book moves',
+                           'Please check your internet connection. Lichess could also be down.',
+                           this.props.forceFetchBookMoves,
+                           'Try again',
+                           <Cached />)
         }
 
         return <MovesTable movesToShow={this.props.bookMoves.moves} namespace='book'
@@ -58,26 +54,6 @@ export default class BookMove extends React.Component {
                 />
     }
 
-    offCard(title, message, action, actionText, actionIcon) {
-        return <Card className="errorCard"><CardBody className="singlePadding">
-        <CardTitle className="smallBottomMargin"><FontAwesomeIcon icon={faInfoCircle} className="lowOpacity"/> {title}</CardTitle>
-        <CardText className="smallText">
-            {message}
-            <br/>
-            <br/>
-            {actionText?<MaterialUIButton
-            onClick={action}
-            variant="contained"
-            color="default"
-            className="mainButton" disableElevation
-            startIcon={actionIcon}
-            >
-                {actionText}
-            </MaterialUIButton>:null}
-        </CardText>
-        </CardBody>
-        </Card>
-    }
     resultsTable() {
         return <ResultsTable gameResults={this.props.gameResults}
                 launchGame={this.props.launchGame}/>

--- a/src/pres/moves/MovesCommon.js
+++ b/src/pres/moves/MovesCommon.js
@@ -1,3 +1,35 @@
+import React from 'react'
+import { Card, CardBody, CardText, CardTitle } from 'reactstrap'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faInfoCircle} from '@fortawesome/free-solid-svg-icons'
+import { Button as MaterialUIButton } from '@material-ui/core'
+
 export function playerDetails(name, elo) {
     return `${name}${elo?`(${elo})`:''}`
+}
+
+export function offCard(title, message, action, actionText, actionIcon) {
+    return <Card className="errorCard">
+               <CardBody className="singlePadding">
+                   <CardTitle className="smallBottomMargin">
+                       <FontAwesomeIcon icon={faInfoCircle}
+                                        className="lowOpacity"/>
+		       {' ' + title}
+                   </CardTitle>
+                   <CardText className="smallText">
+                       {message}<br/><br/>
+                       {actionText ?
+                        <MaterialUIButton onClick={action}
+                                          variant="contained"
+                                          color="default"
+                                          className="mainButton"
+                                          disableElevation
+                                          startIcon={actionIcon}>
+                            {actionText}
+                        </MaterialUIButton>
+                        :
+                        null}
+                   </CardText>
+               </CardBody>
+           </Card>
 }

--- a/src/pres/moves/MovesTable.js
+++ b/src/pres/moves/MovesTable.js
@@ -9,7 +9,7 @@ import "react-step-progress-bar/styles.css";
 import {trackEvent} from '../../app/Analytics'
 import * as Constants from '../../app/Constants'
 import { ProgressBar,Step } from "react-step-progress-bar";
-import {playerDetails} from './MovesCommon'
+import {playerDetails, offCard} from './MovesCommon'
 import {simplifyCount} from '../../app/util'
 import MovesSettings from './MovesSettings'
 
@@ -165,8 +165,20 @@ export default class MovesTable extends React.Component {
 
     render() {
         let hasMoves = (this.props.movesToShow && this.props.movesToShow.length>0)
+        if (!hasMoves)
+            return offCard(
+                'No moves found',
+                'The opening book does not have any moves in this position',
+                this.toggleMovesSettings.bind(this),
+                <b>Modify Book Settings
+                    <MovesSettings isOpen={this.state.moveSettingsOpen}
+                                   toggle={this.toggleMovesSettings.bind(this)}
+                                   settingsChange={this.props.settingsChange}
+                                   updateSettings={this.props.updateSettings}
+                                   settings={this.props.settings}
+                                   variant={this.props.variant}/></b>)
+
         return <Table>
-            {hasMoves?
         <TableHead>
         <TableRow>
             <TableCell size="small" className="smallCol"><b>Move</b></TableCell>
@@ -182,8 +194,6 @@ export default class MovesTable extends React.Component {
                     variant={this.props.variant}/>
             </TableCell>
         </TableRow></TableHead>
-        :null}
-        {hasMoves?
         <TableBody>
         {
         this.props.movesToShow.map((move, moveIndex) => {
@@ -195,7 +205,6 @@ export default class MovesTable extends React.Component {
             }
         )}
     </TableBody>
-    :null}
         <TableFooter><TableRow>
             <TableCell colSpan="3">
                 {this.props.tableFooter}


### PR DESCRIPTION
Hello!

Since the lichess db is partially down, I hit the following unpleasant behavior in the opening explorer tab:
* change to master games
* no moves found in starting position
* can't open settings to switch back to lichess user games
* clear cookies to get out of stuck state


So, the purpose of this patch is to make it so that it's always possible to open the book settings. I factored out the offCard procedure to MovesCommon.js and moved the check for no moves to only the MovesTable.render procedure. Now, if there are no moves the table renders an offCard with a button to open the settings. I based this off the state where the opening books are off and there is a button to turn them on.

Hopefully the modifications are acceptable and if not I'm happy to make changes (naturally)!