### PR TITLE
Add options to save and load openingtree data from browser

### DIFF
--- a/src/app/BrowserStorage.js
+++ b/src/app/BrowserStorage.js
@@ -1,0 +1,18 @@
+import { SAVED_TREE_LOCALSTORAGE_KEY } from '../app/Constants'
+
+export function saveOpeningTree(openingTreeObject) {
+    window.localStorage.setItem(
+        SAVED_TREE_LOCALSTORAGE_KEY,
+        JSON.stringify(openingTreeObject)
+    )
+}
+
+export function loadOpeningTree() {
+    try {
+        return JSON.parse(
+            window.localStorage.getItem(SAVED_TREE_LOCALSTORAGE_KEY)
+        )
+    } catch (err) {
+        return null
+    }
+}

--- a/src/app/BrowserStorage.js
+++ b/src/app/BrowserStorage.js
@@ -1,10 +1,14 @@
 import { SAVED_TREE_LOCALSTORAGE_KEY } from '../app/Constants'
 
 export function saveOpeningTree(openingTreeObject) {
-    window.localStorage.setItem(
-        SAVED_TREE_LOCALSTORAGE_KEY,
-        JSON.stringify(openingTreeObject)
-    )
+    try {
+        window.localStorage.setItem(
+            SAVED_TREE_LOCALSTORAGE_KEY,
+            JSON.stringify(openingTreeObject)
+        )
+    } catch (err) {
+        alert(`Error: ${err.message}`)
+    }
 }
 
 export function loadOpeningTree() {
@@ -13,6 +17,6 @@ export function loadOpeningTree() {
             window.localStorage.getItem(SAVED_TREE_LOCALSTORAGE_KEY)
         )
     } catch (err) {
-        return null
+        alert(`Error: ${err.message}`)
     }
 }

--- a/src/app/Constants.js
+++ b/src/app/Constants.js
@@ -101,3 +101,4 @@ export const SETTING_NAME_MOVES_SETTINGS = 'movesSettings'
 
 export const MILLISECS_IN_DAY = 1000 * 60 * 60 * 24;
 export const SAVED_TREE_LOCALSTORAGE_KEY = "savedtree"
+export const STORAGE_USABLE = typeof Storage !== 'undefined'

--- a/src/app/Constants.js
+++ b/src/app/Constants.js
@@ -19,6 +19,7 @@ export const SITE_EVENT_DB = "eventdb"
 export const SITE_PLAYER_DB = "playerdb"
 export const SITE_OPENING_TREE_FILE = "opntfile"
 export const SITE_ONLINE_TOURNAMENTS = "tournament"
+export const SITE_BROWSER_SAVED_OPENING_TREE = "opntbrowser"
 
 export const MAX_DOWNLOAD_LIMIT = 2000
 export const MAX_ELO_RATING = 3000
@@ -99,3 +100,4 @@ export const SETTING_NAME_DARK_MODE = 'darkMode'
 export const SETTING_NAME_MOVES_SETTINGS = 'movesSettings'
 
 export const MILLISECS_IN_DAY = 1000 * 60 * 60 * 24;
+export const SAVED_TREE_LOCALSTORAGE_KEY = "savedtree"

--- a/src/pres/loader/Actions.js
+++ b/src/pres/loader/Actions.js
@@ -258,6 +258,7 @@ export default class Actions extends React.Component {
                 </MaterialUIButton></span></Tooltip></div>
             }
         {
+          Constants.STORAGE_USABLE &&
             <div className="pgnloadersection"><Tooltip placement="top" title={downloadDisabledReason||"Save your session in the browser for faster reload later"}>
                 <span><MaterialUIButton
                     onClick={this.saveSession.bind(this)}

--- a/src/pres/loader/PGNLoader.js
+++ b/src/pres/loader/PGNLoader.js
@@ -110,6 +110,11 @@ export default class PGNLoader extends React.Component {
         return true
     }
 
+    saveSessionInBrowser(openingTreeSave) {
+        // same logic
+        this.importOpeningTreeObject(openingTreeSave)
+    }
+
     playerDetailsChange(playerName, files, selectedNotableEvent, selectedNotablePlayer, selectedOnlineTournament) {
         this.setState({
             playerName: playerName,
@@ -241,6 +246,7 @@ export default class PGNLoader extends React.Component {
                 selectedNotablePlayer={this.state.selectedNotablePlayer} selectedNotableEvent={this.state.selectedNotableEvent}
                 exportOpeningTreeObject={this.exportOpeningTreeObject.bind(this)} showInfo={this.props.showInfo}
                 importOpeningTreeObject={this.importOpeningTreeObject.bind(this)} selectedOnlineTournament={this.state.selectedOnlineTournament}
+                saveSessionInBrowser={this.saveSessionInBrowser.bind(this)}
                 variant={this.props.variant}/>
         </div>
     }

--- a/src/pres/loader/Source.js
+++ b/src/pres/loader/Source.js
@@ -17,6 +17,7 @@ import {
 
 import {
     Backup,
+    Bookmark,
     DateRange,
     ExpandMore,
     People,
@@ -49,6 +50,8 @@ export default class Source extends React.Component {
             return <span>{addNumber?getNumberIcon('done', addNumber):null}<Save className="lowOpacity"/><span className="sourceName"> Load <b>.tree</b> file</span></span>
         } else if (source === Constants.SITE_ONLINE_TOURNAMENTS) {
             return <span>{addNumber?getNumberIcon('done', addNumber):null}<FontAwesomeIcon icon={faChessRook} className="lowOpacity" /><span className="sourceName"> Lichess tournaments</span></span>
+        } else if (source === Constants.SITE_BROWSER_SAVED_OPENING_TREE) {
+            return <span>{addNumber?getNumberIcon('done', addNumber):null}<Bookmark className="lowOpacity" /><span className="sourceName">Restore saved session</span></span>
         }
         return <span>{getNumberIcon(1, addNumber)}Select a source</span>
     }
@@ -86,6 +89,7 @@ export default class Source extends React.Component {
                 {this.getSourceRadio(Constants.SITE_CHESS_DOT_COM)}
                 {this.getSourceRadio(Constants.SITE_ONLINE_TOURNAMENTS)}
                 {this.getSourceRadio(Constants.SITE_OPENING_TREE_FILE)}
+                {this.getSourceRadio(Constants.SITE_BROWSER_SAVED_OPENING_TREE)}
                 {this.props.variant === Constants.VARIANT_STANDARD?<Divider className="dividerMargin"/>:null}
                 {this.getSourceRadio(Constants.SITE_PLAYER_DB)}
                 {this.getSourceRadio(Constants.SITE_EVENT_DB)}

--- a/src/pres/loader/Source.js
+++ b/src/pres/loader/Source.js
@@ -89,7 +89,7 @@ export default class Source extends React.Component {
                 {this.getSourceRadio(Constants.SITE_CHESS_DOT_COM)}
                 {this.getSourceRadio(Constants.SITE_ONLINE_TOURNAMENTS)}
                 {this.getSourceRadio(Constants.SITE_OPENING_TREE_FILE)}
-                {this.getSourceRadio(Constants.SITE_BROWSER_SAVED_OPENING_TREE)}
+                {Constants.STORAGE_USABLE && this.getSourceRadio(Constants.SITE_BROWSER_SAVED_OPENING_TREE)}
                 {this.props.variant === Constants.VARIANT_STANDARD?<Divider className="dividerMargin"/>:null}
                 {this.getSourceRadio(Constants.SITE_PLAYER_DB)}
                 {this.getSourceRadio(Constants.SITE_EVENT_DB)}

--- a/src/pres/loader/User.js
+++ b/src/pres/loader/User.js
@@ -18,6 +18,7 @@ import LockOpen from '@material-ui/icons/Lock'
 import ExitToApp from '@material-ui/icons/ExitToApp'
 import {Spinner} from 'reactstrap'
 import { trackEvent } from '../../app/Analytics'
+import * as BrowserStorage from '../../app/BrowserStorage'
 
 export default class User extends React.Component {
     constructor(props) {
@@ -156,6 +157,10 @@ export default class User extends React.Component {
                     tournamentType:tournamentType
                 
                 }
+            }
+        } else if (this.props.site === Constants.SITE_BROWSER_SAVED_OPENING_TREE) {
+            if (!BrowserStorage.loadOpeningTree()) {
+                return false
             }
         }
         return true
@@ -405,6 +410,36 @@ export default class User extends React.Component {
         </div>
     }
 
+    getSavedSession() {
+        const savedSession = BrowserStorage.loadOpeningTree()
+        const { header } = savedSession || {}
+
+        return <div>
+            <Card>
+                <CardBody className="singlePadding">
+                <CardTitle className="smallBottomMargin"><FontAwesomeIcon icon={faInfoCircle} className="lowOpacity"/> How it works</CardTitle>
+                <CardText className="smallText">
+                    If you plan to revisit the same player, you can save your session to the browser by loading a tree and then clicking <i>"Save session to browser"</i>.
+                </CardText>
+                </CardBody>
+                </Card><br/>
+            <div>
+                {!savedSession ?
+                    <div>
+                        You do not have a saved session on OpeningTree. Please select another source.
+                    </div>
+                    : <div>
+                        You have a previously saved session with details:
+                        <p>Player Name: {header.settings.playerName}</p>
+                        <p>Player Color: {header.settings.playerColor}</p>
+                        <p>Site: {header.site}</p>
+                        <p>Timestamp: {(new Date(header.timestamp * 1000)).toLocaleString()}</p>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+
     getInputsToShow() {
         if(this.props.site === Constants.SITE_PGN_FILE) {
             return this.getPgnFileSelection()
@@ -420,6 +455,8 @@ export default class User extends React.Component {
             return this.getOpeningTreeSelection()
         } else if(this.props.site === Constants.SITE_ONLINE_TOURNAMENTS) {
             return this.getOnlineTournamentSelection()
+        } else if (this.props.site === Constants.SITE_BROWSER_SAVED_OPENING_TREE) {
+            return this.getSavedSession()
         }
         return <div/>
     }


### PR DESCRIPTION
Similar to .tree file functions (load and save) but saved in localStorage instead of a file.

Did this because sometimes I accidentally quit / reload the page and all the data is lost. I personally find this more convenient than saving to a file, and I think others will too.

Edit: Another idea is to turn this into an **autosave** feature which can be toggled on or off

![browser session demo](https://user-images.githubusercontent.com/22242264/126889719-f1c65d67-5490-4d66-8ec2-b1055bde00d2.gif)