### PR TITLE
serialize: don't skip chunk index 1

### DIFF
--- a/src/app/OpeningTreeSerializer.js
+++ b/src/app/OpeningTreeSerializer.js
@@ -140,7 +140,7 @@ function chunk(treeData) {
 function chunkArray(array, chunkSize, startIndex) {
     let chunkedArray=[]
     
-    for (let i=0, chunkIndex=1; i<array.length; i+=chunkSize, chunkIndex++) {
+    for (let i=0, chunkIndex=0; i<array.length; i+=chunkSize, chunkIndex++) {
         chunkedArray.push({chunk:array.slice(i,i+chunkSize), index:startIndex+chunkIndex});
     }
     return chunkedArray


### PR DESCRIPTION
The chunkArray() function is called with chunks.length for the startIndex parameter.  The next usable index in a 0-based array is array.length, not array.length+1.  As a result, chunkArray skips the first index, and the .tree file has no chunk with index 1.

The off-by-one error doesn't affect OpeningTree itself, since it only uses the index for sort order, but it can make it inconvenient if you're trying to write a separate tool to work with, say, multiple .tree files.