### PR TITLE
Add possibility to filter by game outcome

### DIFF
--- a/src/app/Common.js
+++ b/src/app/Common.js
@@ -25,6 +25,18 @@ export const TIME_CONTROL_LABELS = {
     [Constants.TIME_CONTROL_DAILY]: "Daily"
 }
 
+export const OUTCOMES = [
+    Constants.OUTCOME_LOSE,
+    Constants.OUTCOME_DRAW,
+    Constants.OUTCOME_WIN
+]
+
+export const OUTCOME_LABELS = {
+    [Constants.OUTCOME_LOSE]: "Lost",
+    [Constants.OUTCOME_DRAW]: "Draw",
+    [Constants.OUTCOME_WIN]: "Won",
+}
+
 export function trimString(str) {
     return str.replace(/^\s+|\s+$/g, '')
 }

--- a/src/app/Constants.js
+++ b/src/app/Constants.js
@@ -8,6 +8,7 @@ export const TIME_CONTROL_DAILY = "daily"
 export const FILTER_NAME_RATED = "rated"
 export const FILTER_NAME_DOWNLOAD_LIMIT = "downloadLimit"
 export const FILTER_NAME_OPPONENT = "opponent"
+export const FILTER_OUTCOME = "outcome"
 export const FILTER_NAME_ELO_RANGE = "eloRange"
 export const FILTER_NAME_FROM_DATE = "fromDate"
 export const FILTER_NAME_TO_DATE = "toDate"
@@ -93,6 +94,11 @@ export const OPENING_BOOK_TYPE_MASTERS = 'master'
 export const OPENING_BOOK_TYPE_LICHESS = 'lichess'
 
 export const ALL_BOOK_RATINGS = ['1600','1800','2000','2200','2500']
+
+export const OUTCOME = 'outcome'
+export const OUTCOME_LOSE = 'lose'
+export const OUTCOME_WIN = 'win'
+export const OUTCOME_DRAW = 'draw'
 
 export const SETTING_NAME_ORIENTATION = 'orientation'
 export const SETTING_NAME_DARK_MODE = 'darkMode'

--- a/src/app/iterator/LichessIterator.js
+++ b/src/app/iterator/LichessIterator.js
@@ -1,4 +1,4 @@
-import {getTimeControlsArray, isOpponentEloInSelectedRange} from '../util'
+import {getOutcomesArray, getTimeControlsArray, isAcceptedOutcome, isOpponentEloInSelectedRange} from '../util'
 import * as Constants from '../Constants'
 import * as Common from '../Common'
 import BaseLichessIterator from './BaseLichessIterator'
@@ -28,6 +28,13 @@ export default class LichessIterator {
                 let opponentElo = playerColor === Constants.PLAYER_COLOR_WHITE?pgn.headers.BlackElo:pgn.headers.WhiteElo
                 if(!isOpponentEloInSelectedRange(opponentElo, advancedFilters[Constants.FILTER_NAME_ELO_RANGE])) {
                     return false
+                }
+
+                let outcomesArray = getOutcomesArray(advancedFilters)
+                if (pgn && pgn.headers.Result && outcomesArray && outcomesArray.length > 0) {
+                    if (!isAcceptedOutcome(pgn.headers.Result, outcomesArray)) {
+                        return false
+                    }
                 }
                 return true
             },

--- a/src/app/util.js
+++ b/src/app/util.js
@@ -23,6 +23,24 @@ export function getTimeControlsArray(site,timeControlState, selected) {
     return allTimeControls.filter((timeControl)=>!!timeControlState[timeControl] === selected)
 }
 
+export function isAcceptedOutcome(outcome, acceptedOutcomes) {
+    let isWin = outcome === "1-0"
+    let isLose = outcome === "0-1"
+
+    if (isLose && acceptedOutcomes.indexOf(Constants.OUTCOME_LOSE) === -1) {
+        return false
+    } else if (isWin && acceptedOutcomes.indexOf(Constants.OUTCOME_WIN) === -1) {
+        return false
+    } else if (!isLose && !isWin && acceptedOutcomes.indexOf(Constants.OUTCOME_DRAW) === -1) {
+        return false
+    }
+    return true
+}
+
+export function getOutcomesArray(outcomeState) {
+    return Common.OUTCOMES.filter((timeControl)=>!!outcomeState[timeControl])
+}
+
 export function simplifyCount(count){
     if(count>=1000000){
         return `${(count/1000000).toFixed(1)}M`

--- a/src/pres/loader/AdvancedFilters.js
+++ b/src/pres/loader/AdvancedFilters.js
@@ -6,7 +6,7 @@ import {Collapse, Container, Row, Col, Badge} from 'reactstrap'
 import { FormControlLabel,Slider } from '@material-ui/core';
 import * as Constants from '../../app/Constants'
 import {getTimeControlLabel, getELORangeLabel, getRatedLabel, 
-    getDownloadLimitLabel, opponentNameLabel, getFromDateLabel, getToDateLabel} from './FilterLabels'
+    getDownloadLimitLabel, opponentNameLabel, getFromDateLabel, getToDateLabel, getOutcomesLabel } from './FilterLabels'
 import * as Common from '../../app/Common'
 import { trackEvent } from '../../app/Analytics'
 import { TextField } from '@material-ui/core'
@@ -78,6 +78,11 @@ export default class AdvancedFilters extends React.Component {
                 <Collapse isOpen={this.state.currentlyOpenAdvancedFilter === 'opponent'}>
                     {this.getOpponentNameFilter()}
                 </Collapse>, true)}
+            {this.subSectionComponent('Game outcome', getOutcomesLabel(this.props.advancedFilters),
+                this.setCurrentlyOpenAdvancedFilter(Constants.FILTER_OUTCOME).bind(this),
+                <Collapse isOpen={this.state.currentlyOpenAdvancedFilter === Constants.FILTER_OUTCOME}>
+                    {this.getOutcomeFilters()}
+                </Collapse>)}
             {this.subSectionComponent('Download limit', getDownloadLimitLabel(this.props.advancedFilters[Constants.FILTER_NAME_DOWNLOAD_LIMIT]), 
                 this.setCurrentlyOpenAdvancedFilter('downloadLimit').bind(this),
                 <Collapse isOpen={this.state.currentlyOpenAdvancedFilter === 'downloadLimit'}>
@@ -124,6 +129,19 @@ export default class AdvancedFilters extends React.Component {
             label={"Opponent Name"} variant="outlined" value={this.props.advancedFilters[Constants.FILTER_NAME_OPPONENT]}/>
     }
 
+    getOutcomeFilters() {
+        let row = [Constants.OUTCOME_DRAW,
+            Constants.OUTCOME_LOSE, Constants.OUTCOME_WIN]
+        let colWidth = '3'
+        return <FormControl>
+            <FormGroup>
+                <Container>
+                    {this.getFilterRow(row, colWidth, 'first', Common.OUTCOME_LABELS)}
+                </Container>
+            </FormGroup>
+        </FormControl>
+    }
+
     getTimeControlFilters(site){
         let firstRow = null, middleRow = null, lastRow = null
         let colWidth = null
@@ -144,15 +162,15 @@ export default class AdvancedFilters extends React.Component {
             colWidth = '6'
         }
         return <FormControl><FormGroup><Container>
-            {this.getTimeControlFilterRow(firstRow,colWidth,'first')}
-            {middleRow?this.getTimeControlFilterRow(middleRow,colWidth,'middle'):null}
-            {this.getTimeControlFilterRow(lastRow,colWidth,'last')}
+            {this.getFilterRow(firstRow,colWidth,'first', Common.TIME_CONTROL_LABELS)}
+            {middleRow?this.getFilterRow(middleRow,colWidth,'middle', Common.TIME_CONTROL_LABELS):null}
+            {this.getFilterRow(lastRow,colWidth,'last', Common.TIME_CONTROL_LABELS)}
           </Container>
         </FormGroup></FormControl>
       
     }
 
-    getTimeControlFilterRow(controls,firstColumnWidth, position){
+    getFilterRow(controls,firstColumnWidth, position, labels){
         let clsName = 'topBottomNegativeMargin'
         if(position === "first") {
             clsName = 'bottomNegativeMargin'
@@ -165,8 +183,8 @@ export default class AdvancedFilters extends React.Component {
                 
             <FormControlLabel className = "nomargin"
                 control={<Checkbox checked={this.props.advancedFilters[control]} color="primary" 
-                onChange={this.props.handleTimeControlChange} name={control} />}
-                label={Common.TIME_CONTROL_LABELS[control]}
+                onChange={this.props.handleRootLevelChange} name={control} />}
+                label={labels[control]}
           /></Col>)}</Row>
     }
 

--- a/src/pres/loader/Common.js
+++ b/src/pres/loader/Common.js
@@ -33,7 +33,11 @@ export function advancedFilters(state) {
         Constants.TIME_CONTROL_CLASSICAL, Constants.FILTER_NAME_RATED,
         Constants.FILTER_NAME_DOWNLOAD_LIMIT,
         Constants.FILTER_NAME_ELO_RANGE, Constants.FILTER_NAME_OPPONENT,
-        Constants.FILTER_NAME_FROM_DATE, Constants.FILTER_NAME_TO_DATE])
+        Constants.FILTER_NAME_FROM_DATE, Constants.FILTER_NAME_TO_DATE,
+        Constants.OUTCOME_DRAW,
+        Constants.OUTCOME_LOSE,
+        Constants.OUTCOME_WIN,
+    ])
 }
 
 export function copyText(elementId) {

--- a/src/pres/loader/FilterLabels.js
+++ b/src/pres/loader/FilterLabels.js
@@ -1,5 +1,7 @@
 import {timeControlLabel} from './TimeControlLabels'
+import { getOutcomesArray } from '../../app/util'
 import * as Constants from '../../app/Constants'
+import { OUTCOMES, OUTCOME_LABELS } from '../../app/Common'
 
 export const getTimeControlLabel = timeControlLabel
 
@@ -30,6 +32,19 @@ export function opponentNameLabel(value) {
 }
 export function getDownloadLimitLabel(downloadLimit) {
     return downloadLimit>= Constants.MAX_DOWNLOAD_LIMIT?"No limit":`${downloadLimit} games`
+}
+
+function getOutcomeLabel(outcome) {
+    return OUTCOME_LABELS[outcome.toLowerCase()]
+}
+
+export function getOutcomesLabel(outcomeState) {
+    let outcomes = getOutcomesArray(outcomeState)
+    if (outcomes.length === OUTCOMES.length) {
+        return 'All'
+    } else {
+        return outcomes.map(x => getOutcomeLabel(x)).join(" and ")
+    }
 }
 
 export function getFromDateLabel(date) {

--- a/src/pres/loader/Filters.js
+++ b/src/pres/loader/Filters.js
@@ -57,7 +57,7 @@ export default class Filters extends React.Component {
             setImmediate(this.setFilters.bind(this))
         }
 }
-    handleTimeControlChange(event) {
+    handleRootLevelChange(event) {
         this.setState({ [event.target.name]: event.target.checked });
     }
     handleEloRangeChange(event, newValue) {
@@ -138,7 +138,7 @@ export default class Filters extends React.Component {
                             <AdvancedFilters
                                 site={this.props.site}
                                 toggleRated={this.toggleRated.bind(this)}
-                                handleTimeControlChange={this.handleTimeControlChange.bind(this)}
+                                handleRootLevelChange={this.handleRootLevelChange.bind(this)}
                                 handleEloRangeChange={this.handleEloRangeChange.bind(this)}
                                 handleOpponentNameChange={this.handleOpponentNameChange.bind(this)}
                                 handleDownloadLimitChange={this.handleDownloadLimitChange.bind(this)}

--- a/src/pres/loader/PGNLoader.js
+++ b/src/pres/loader/PGNLoader.js
@@ -46,6 +46,9 @@ export default class PGNLoader extends React.Component {
         this.state[Constants.FILTER_NAME_RATED] = "all"
         this.state[Constants.FILTER_NAME_ELO_RANGE] = [0, Constants.MAX_ELO_RATING]
         this.state[Constants.FILTER_NAME_OPPONENT] = ''
+        this.state[Constants.OUTCOME_DRAW] = true
+        this.state[Constants.OUTCOME_WIN] = true
+        this.state[Constants.OUTCOME_LOSE] = true
     }
 
 
@@ -57,7 +60,11 @@ export default class PGNLoader extends React.Component {
             Constants.TIME_CONTROL_CLASSICAL, Constants.FILTER_NAME_RATED,
             Constants.FILTER_NAME_DOWNLOAD_LIMIT,
             Constants.FILTER_NAME_ELO_RANGE, Constants.FILTER_NAME_OPPONENT,
-            Constants.FILTER_NAME_FROM_DATE, Constants.FILTER_NAME_TO_DATE])
+            Constants.FILTER_NAME_FROM_DATE, Constants.FILTER_NAME_TO_DATE,
+            Constants.OUTCOME_DRAW,
+            Constants.OUTCOME_LOSE,
+            Constants.OUTCOME_WIN,
+        ])
     }
 
 


### PR DESCRIPTION
Add the possibility to filter on either draw, win or lose outcomes on
games from lichess and chess.com.

As the APIs do not expose this information directly this is implemented
as a post filter.